### PR TITLE
ci: fix Tests workflow startup_failure (install PHP 8.4 via ondrej PPA)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,12 +12,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.4'
-          extensions: sqlite3, pdo_sqlite
-          coverage: none
+      # The repo restricts Actions to an allowlist (GitHub-owned + verified
+      # creators + golangci-lint), which excludes shivammathur/setup-php, so
+      # PHP 8.4 is installed from the ondrej/php PPA instead. 8.4 matches the
+      # composer `config.platform.php` pin; sqlite3 provides the pdo_sqlite
+      # driver used by phpunit.xml's :memory: database.
+      - name: Setup PHP 8.4
+        run: |
+          sudo add-apt-repository -y ppa:ondrej/php
+          sudo apt-get update
+          sudo apt-get install -y \
+            php8.4-cli \
+            php8.4-sqlite3 \
+            php8.4-mbstring \
+            php8.4-xml \
+            php8.4-curl \
+            php8.4-zip
+          sudo update-alternatives --set php /usr/bin/php8.4
+          php -v | grep -q 'PHP 8\.4' || { echo '::error::PHP 8.4 is not the active CLI'; php -v; exit 1; }
 
       - name: Cache Composer dependencies
         uses: actions/cache@v4


### PR DESCRIPTION
Follow-up to #34. The `tests.yml` merged in #34 never actually runs — it fails at **startup**, so the Tests check goes red without executing a single step.

## Why it fails

This repo restricts GitHub Actions to an allowlist (`allowed_actions: selected`): GitHub-owned actions, verified-creator actions, and `golangci/golangci-lint-action`. The workflow from #34 uses `shivammathur/setup-php@v2`, which is **none of those**, so GitHub rejects the run at startup:

```
completed  startup_failure  Tests  ...  pull_request  0s
```

`docker-image.yml` is unaffected because the `docker/*` actions it uses are verified-creator actions. `actions/checkout` and `actions/cache` are GitHub-owned, so both remain allowed.

## Fix

Replace the `shivammathur/setup-php` step with an `ondrej/php` PPA install driven by plain shell, keeping only the allowlisted `actions/checkout` and `actions/cache`. No change to the repo's Actions security policy is required.

- PHP `8.4` matches the `composer` `config.platform.php` pin (a lower runtime aborts at autoload via `platform_check.php`).
- `php8.4-sqlite3` provides `pdo_sqlite` for `phpunit.xml`'s `:memory:` database.
- `mbstring` / `xml` / `curl` / `zip` cover Laravel 12, PHPUnit 11, and `composer --prefer-dist`.
- A `php -v` guard fails fast with a clear error if 8.4 is not the active CLI.

The Tests check on this PR exercises the new workflow end-to-end — it should now run the suite and go green instead of erroring at startup.

Refs #27